### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,8 @@
 name: Code Quality
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/arnavk23/3D_PointCloud_Segmentation/security/code-scanning/7](https://github.com/arnavk23/3D_PointCloud_Segmentation/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow primarily involves linting and checking files, it likely only needs read access to the repository contents. We will add the `permissions` block at the root level of the workflow to apply it to all jobs, ensuring consistency and reducing the risk of excessive permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
