### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/compile-latex.yml
+++ b/.github/workflows/compile-latex.yml
@@ -1,5 +1,9 @@
 name: Compile LaTeX Report
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches: [ main, develop ]


### PR DESCRIPTION
Potential fix for [https://github.com/arnavk23/3D_PointCloud_Segmentation/security/code-scanning/2](https://github.com/arnavk23/3D_PointCloud_Segmentation/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the workflow's operations, it only needs `contents: read` to check out the repository and `actions: write` to upload artifacts. These permissions will be explicitly set to ensure the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
